### PR TITLE
feat(plugin): prevent diagnostic errors from in unpacking

### DIFF
--- a/resources/test/test.lua
+++ b/resources/test/test.lua
@@ -1,7 +1,8 @@
 local foo = {
 	bar = {
 		'baz'
-	}
+	},
+	bar2 = 'baz2'
 }
 
 ---@param v string
@@ -20,5 +21,12 @@ end
 -- if foo and foo.bar then
 --	   print(foobar('bar'))
 -- end
+
+
+-- In unpacking can be easier to write and read.
+-- local bar, bar2 = t.bar, t.bar2
+local bar, bar2 in foo
+print(bar)
+print(bar2)
 
 GetPlayerPed()


### PR DESCRIPTION
Prevent diagnostic errors from [in unpacking](https://github.com/citizenfx/fivem-docs/pull/301/files#diff-5900c2a5ad7160b6e6263260697d18ff7f5d766de0153e67dc5420d8b4a3c3acR26).

An example for it would be
```lua
local a, b, c in t
```
which would be equivalent for
```lua
local a, b, c = t.a, t.b, t.c
```