### PR TITLE
fix(plugin): correct invalid match patterns

### DIFF
--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -15,7 +15,7 @@ function OnSetText(uri, text)
 	end
 
 	-- prevent diagnostic errors from in unpacking (a, b, c in t)
-	for vars, inPos, afterInPos, tablePos, tableName, finishPos in text:gmatch '([_%w, ]*)%s+()in()%s+()([_%w]*)()' do
+	for vars, inPos, afterInPos, tablePos, tableName, finishPos in text:gmatch '([_%w, ]*)%s+()in()%s+()([_%w]*%s-%(?.-%)?)()' do
 		if tableName ~= 'ipairs' and tableName ~= 'pairs' and not vars:find('^%s*for%s') then
 			-- replace 'in' with '='
 			count = count + 1

--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -1,5 +1,5 @@
 function OnSetText(uri, text)
-	if string.find(uri, '.vscode') or text:sub(1, 8) == "---@meta" then return end
+	if string.find(uri, '[\\/]%.vscode[\\/]') or text:sub(1, 8) == "---@meta" then return end
 
 	local diffs = {}
 	local count = 0

--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -16,7 +16,7 @@ function OnSetText(uri, text)
 
 	-- prevent diagnostic errors from in unpacking (a, b, c in t)
 	for vars, inPos, afterInPos, tablePos, tableName, finishPos in text:gmatch '([_%w, ]*)%s+()in()%s+()([_%w]*%s-%(?.-%)?)()' do
-		if tableName ~= 'ipairs' and tableName ~= 'pairs' and not vars:find('^%s*for%s') then
+		if not vars:find('^%s*for%s') then
 			-- replace 'in' with '='
 			count = count + 1
 			diffs[count] = {

--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -16,7 +16,7 @@ function OnSetText(uri, text)
 
 	-- prevent diagnostic errors from in unpacking (a, b, c in t)
 	for vars, inPos, afterInPos, tablePos, tableName, finishPos in text:gmatch '([_%w, ]*)%s+()in()%s+()([_%w]*)()' do
-		if tableName ~= 'ipairs' and tableName ~= 'pairs' and vars:sub(1, 3) ~= 'for' then
+		if tableName ~= 'ipairs' and tableName ~= 'pairs' and not vars:find('^%s*for%s') then
 			-- replace 'in' with '='
 			count = count + 1
 			diffs[count] = {
@@ -26,8 +26,8 @@ function OnSetText(uri, text)
 			}
 
 			-- replace 't' with 't.a, t.b, t.c'
-			if vars:sub(1, 5) == 'local' then vars = vars:sub(7) end
 			local tableVars = ''
+			vars = vars:gsub('^%s*local%s', '')
 
 			for varName in vars:gsub('%s+', ''):gmatch('([_%w]+)') do
 				if #tableVars > 0 then tableVars = tableVars .. ',' end


### PR DESCRIPTION
Only ignore file if in `.vscode` directory and not just if `vscode` is in path.
~~Ignore file if `---@meta` is anywhere in the file, not only the beginning.~~ Bad for performance :/
Fix `for` and `local` not being detected for in unpacking when code is indented.
Fix in unpacking not working for functions.