### PR TITLE
Prevent most `need check nil` errors in safe navigation

### DIFF
--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -27,24 +27,31 @@ function OnSetText(uri, text)
 		}
 	end
 
-	-- prevent diagnostic errors from safe navigation (foo?.bar)
-	for startPos, tableName, finishPos in str_gmatch(text, '()([_%w]+)?()%.[_%w]+') do
+	-- prevent diagnostic errors from safe navigation
+	for pos in str_gmatch(text, '()%?[%.%[]+') do
 		count = count + 1
 		diffs[count] = {
-			start  = startPos,
-			finish = finishPos - 1,
-			text   = '(' .. tableName .. ' or {})',
+			start  = pos,
+			finish = pos,
+			text   = '',
 		}
 	end
 
-	-- prevent diagnostic errors from safe navigation (foo?[bar])
-	for startPos, tableName, finishPos, index in str_gmatch(text, '()([_%w]+)?()(%b[])') do
-		local indexBeginning = str_sub(index, 1, 2)
-		if indexBeginning ~= '[[' and indexBeginning ~= '[=' then -- ignore strings ([[]])
+	-- prevent nil check errors from most safe navigations
+	for startPos, tableName, finishPos in str_gmatch(text, '()([_%w]+)%?()%.[_%w]+') do
+		count = count + 1
+		diffs[count] = {
+			start  = startPos,
+			finish = finishPos - 2,
+			text   = '(' .. tableName .. ' or {})',
+		}
+	end
+	for startPos, tableName, finishPos, index in str_gmatch(text, '()([_%w]+)%?()(%b[])') do
+		if str_sub(index, 1, 2) ~= '[[' then -- ignore strings ([[]])
 			count = count + 1
 			diffs[count] = {
 				start  = startPos,
-				finish = finishPos - 1,
+				finish = finishPos - 2,
 				text   = '(' .. tableName .. ' or {})',
 			}
 		end

--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -39,7 +39,8 @@ function OnSetText(uri, text)
 
 	-- prevent diagnostic errors from safe navigation (foo?[bar])
 	for startPos, tableName, finishPos, index in str_gmatch(text, '()([_%w]+)?()(%b[])') do
-		if str_sub(index, 1, 2) ~= '[[' then -- ignore strings ([[]])
+		local indexBeginning = str_sub(index, 1, 2)
+		if indexBeginning ~= '[[' and indexBeginning ~= '[=' then -- ignore strings ([[]])
 			count = count + 1
 			diffs[count] = {
 				start  = startPos,

--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -27,13 +27,23 @@ function OnSetText(uri, text)
 		}
 	end
 
-	-- prevent diagnostic errors from safe navigation (foo?.bar and foo?[bar])
-	for safeNav in str_gmatch(text, '()%?[%.%[]+') do
+	-- prevent diagnostic errors from safe navigation (foo?.bar)
+	for startPos, tableName, finishPos in str_gmatch(text, '()([_%w]+)?()%.[_%w]+') do
 		count = count + 1
 		diffs[count] = {
-			start  = safeNav,
-			finish = safeNav,
-			text   = '',
+			start  = startPos,
+			finish = finishPos - 1,
+			text   = '(' .. tableName .. ' or {})',
+		}
+	end
+
+	-- prevent diagnostic errors from safe navigation (foo?[bar])
+	for startPos, tableName, finishPos in str_gmatch(text, '()([_%w]+)?()%b[]') do
+		count = count + 1
+		diffs[count] = {
+			start  = startPos,
+			finish = finishPos - 1,
+			text   = '(' .. tableName .. ' or {})',
 		}
 	end
 

--- a/Lua/plugin.lua
+++ b/Lua/plugin.lua
@@ -38,13 +38,15 @@ function OnSetText(uri, text)
 	end
 
 	-- prevent diagnostic errors from safe navigation (foo?[bar])
-	for startPos, tableName, finishPos in str_gmatch(text, '()([_%w]+)?()%b[]') do
-		count = count + 1
-		diffs[count] = {
-			start  = startPos,
-			finish = finishPos - 1,
-			text   = '(' .. tableName .. ' or {})',
-		}
+	for startPos, tableName, finishPos, index in str_gmatch(text, '()([_%w]+)?()(%b[])') do
+		if str_sub(index, 1, 2) ~= '[[' then -- ignore strings ([[]])
+			count = count + 1
+			diffs[count] = {
+				start  = startPos,
+				finish = finishPos - 1,
+				text   = '(' .. tableName .. ' or {})',
+			}
+		end
 	end
 
 	-- prevent diagnostic errors from in unpacking (a, b, c in t)


### PR DESCRIPTION
When using safe navigation (`x?.y?.z`) the syntax will not result in diagnostic errors, but the `Need check nil` error will still appear for possibly nil tables. Example:
![image](https://user-images.githubusercontent.com/43699941/222138282-4ea4e256-c0ed-4a4c-bbcf-a1827f921dc3.png)

To fix this, instead of simply removing the `?`, the table is now also replaced with `(tableName or {})`.

The single `gmatch` was split in two to correctly check for both the `?.` syntax and the `?[...]` syntax.

### Notes (stuff that may not be very simple to fix)

- When using the syntax, the table is highlighted 1 character off:
![image](https://user-images.githubusercontent.com/43699941/222139012-f83142d6-a2ad-47e1-a899-0144d3cabae1.png)